### PR TITLE
Support for completion of "edit <resource>", and "config use-context <context>"

### DIFF
--- a/kube/completer.go
+++ b/kube/completer.go
@@ -194,17 +194,52 @@ func argumentsCompleter(args []string) []prompt.Suggest {
 		if len(args) == 2 {
 			return prompt.FilterHasPrefix(resourceTypes, args[1], true)
 		}
+		second := args[1]
+
 		// TODO: Add suggestions for Deployments
+		third := args[2]
 		if len(args) == 3 {
-			switch args[1] {
-			case "deployments":
-				{
-					return prompt.FilterContains(getDeploymentSuggestions(), args[2], true)
-				}
-			case "replicationcontrollers":
-				{
-					return prompt.FilterContains(getReplicationControllerSuggestions(), args[2], true)
-				}
+			switch second {
+			case "componentstatuses", "cs":
+				return prompt.FilterContains(getComponentStatusCompletions(), third, true)
+			case "configmaps", "cm":
+				return prompt.FilterContains(getConfigMapSuggestions(), third, true)
+			case "daemonsets", "ds":
+				return prompt.FilterContains(getDaemonSetSuggestions(), third, true)
+			case "deploy", "deployments":
+				return prompt.FilterContains(getDeploymentSuggestions(), third, true)
+			case "endpoints", "ep":
+				return prompt.FilterContains(getEndpointsSuggestions(), third, true)
+			case "ingresses", "ing":
+				return prompt.FilterContains(getIngressSuggestions(), third, true)
+			case "limitranges", "limits":
+				return prompt.FilterContains(getLimitRangeSuggestions(), third, true)
+			case "namespaces", "ns":
+				return prompt.FilterContains(getNameSpaceSuggestions(), third, true)
+			case "no", "nodes":
+				return prompt.FilterContains(getNodeSuggestions(), third, true)
+			case "po", "pod", "pods":
+				return prompt.FilterContains(getPodSuggestions(), third, true)
+			case "persistentvolumeclaims", "pvc":
+				return prompt.FilterContains(getPersistentVolumeClaimSuggestions(), third, true)
+			case "persistentvolumes", "pv":
+				return prompt.FilterContains(getPersistentVolumeSuggestions(), third, true)
+			case "podsecuritypolicies", "psp":
+				return prompt.FilterContains(getPodSecurityPolicySuggestions(), third, true)
+			case "podtemplates":
+				return prompt.FilterContains(getPodTemplateSuggestions(), third, true)
+			case "replicasets", "rs":
+				return prompt.FilterContains(getReplicaSetSuggestions(), third, true)
+			case "replicationcontrollers", "rc":
+				return prompt.FilterContains(getReplicationControllerSuggestions(), third, true)
+			case "resourcequotas", "quota":
+				return prompt.FilterContains(getResourceQuotasSuggestions(), third, true)
+			case "secrets":
+				return prompt.FilterContains(getSecretSuggestions(), third, true)
+			case "sa", "serviceaccounts":
+				return prompt.FilterContains(getServiceAccountSuggestions(), third, true)
+			case "svc", "services":
+				return prompt.FilterContains(getServiceSuggestions(), third, true)
 			}
 		}
 

--- a/kube/completer.go
+++ b/kube/completer.go
@@ -194,6 +194,20 @@ func argumentsCompleter(args []string) []prompt.Suggest {
 		if len(args) == 2 {
 			return prompt.FilterHasPrefix(resourceTypes, args[1], true)
 		}
+		// TODO: Add suggestions for Deployments
+		if len(args) == 3 {
+			switch args[1] {
+			case "deployments":
+				{
+					return prompt.FilterContains(getDeploymentSuggestions(), args[2], true)
+				}
+			case "replicationcontrollers":
+				{
+					return prompt.FilterContains(getReplicationControllerSuggestions(), args[2], true)
+				}
+			}
+		}
+
 	case "namespace":
 		if len(args) == 2 {
 			return prompt.FilterContains(getNameSpaceSuggestions(), args[1], true)

--- a/kube/completer.go
+++ b/kube/completer.go
@@ -314,8 +314,17 @@ func argumentsCompleter(args []string) []prompt.Suggest {
 			{Text: "use-context", Description: "Sets the current-context in a kubeconfig file"},
 			{Text: "view", Description: "Display merged kubeconfig settings or a specified kubeconfig file"},
 		}
+		second := args[1]
+
 		if len(args) == 2 {
 			return prompt.FilterHasPrefix(subCommands, args[1], true)
+		}
+		third := args[2]
+		if len(args) == 3 {
+			switch second {
+			case "use-context":
+				return prompt.FilterContains(getContextSuggestions(), third, true)
+			}
 		}
 	case "cluster-info":
 		subCommands := []prompt.Suggest{

--- a/kube/executor.go
+++ b/kube/executor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"bytes"
 )
 
 func Executor(s string) {
@@ -21,4 +22,23 @@ func Executor(s string) {
 		fmt.Printf("Got error: %s\n", err.Error())
 	}
 	return
+}
+
+func ExecuteAndReturnList(s string) (list []string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return
+	}
+
+	out := &bytes.Buffer{}
+	cmd := exec.Command("/bin/sh", "-c", "kubectl "+s)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = out
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Got error: %s\n", err.Error())
+	}
+
+	ss := string(out.Bytes())
+	return strings.Split(ss, "\n")
+
 }

--- a/kube/resource.go
+++ b/kube/resource.go
@@ -126,6 +126,39 @@ func getConfigMapSuggestions() []prompt.Suggest {
 	return s
 }
 
+/* Contexts */
+
+var (
+	contextList        atomic.Value
+	contextLastFetchAt time.Time
+)
+
+func fetchContextList() {
+	if time.Since(contextLastFetchAt) < thresholdFetchInterval {
+		return
+	}
+	// TODO: Get a list of config get-context
+	list := ExecuteAndReturnList("config get-contexts --no-headers -o name")
+
+	contextList.Store(list)
+}
+
+func getContextSuggestions() []prompt.Suggest {
+	go fetchContextList()
+	l, ok := contextList.Load().([]string)
+	if !ok || len(l) == 0 {
+		return []prompt.Suggest{}
+	}
+	s := make([]prompt.Suggest, len(l))
+	for i := range l {
+		s[i] = prompt.Suggest{
+			Text:        l[i],
+			Description: string(l[i]),
+		}
+	}
+	return s
+}
+
 /* Pod */
 
 var (


### PR DESCRIPTION
First off, great tool, and i like the modular framework of go-prompt.

This PR adds completion for "edit <resourcetype> <resource>", as well as easy switching of context from cluster to cluster via "config use-context <cluster>".

Hopefully someone else finds this useful, as i tend to live in a terminal, and switching from environment to environment for rapid management is fantastic.
