### PR TITLE
remove ExplicitPath from loading rules

### DIFF
--- a/kube/client.go
+++ b/kube/client.go
@@ -17,8 +17,6 @@ func getClient() *kubernetes.Clientset {
 
 func NewClient() *kubernetes.Clientset {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.ExplicitPath = clientcmd.RecommendedHomeFile
-
 	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loadingRules,
 		&clientcmd.ConfigOverrides{},


### PR DESCRIPTION
`clientcmd.NewDefaultClientConfigLoadingRules()` already checks for the `KUBECONFIG` env-var and also checks for `~/.kube/config`. Setting an explicit path overrides this.

Fixes #16 
Fixes #10