### PR TITLE
Support for "kubectl top" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Hopefully support following commands enough to operate kubernetes.
 * [x] `version`        Print the client and server version information.
 * [x] `explain`        Documentation of resources.
 * [x] `convert`        Convert config files between different API versions
+* [x] `top`            Display Resource (CPU/Memory/Storage) usage
 
 ## Author
 

--- a/kube/completer.go
+++ b/kube/completer.go
@@ -65,6 +65,7 @@ var commands = []prompt.Suggest{
 	{Text: "version", Description: "Print the client and server version information."},
 	{Text: "explain", Description: "Documentation of resources."},
 	{Text: "convert", Description: "Convert config files between different API versions"},
+	{Text: "top", Description: "Display Resource (CPU/Memory/Storage) usage"},
 
 	// Custom command.
 	{Text: "exit", Description: "Exit this program"},
@@ -433,6 +434,28 @@ func argumentsCompleter(args []string) []prompt.Suggest {
 		}
 	case "explain":
 		return prompt.FilterHasPrefix(resourceTypes, args[1], true)
+	case "top":
+		second := args[1]
+		if len(args) == 2 {
+			subcommands := []prompt.Suggest{
+				{Text: "nodes"},
+				{Text: "pod"},
+				// aliases
+				{Text: "no"},
+				{Text: "po"},
+			}
+			return prompt.FilterHasPrefix(subcommands, second, true)
+		}
+
+		third := args[2]
+		if len(args) == 3 {
+			switch second {
+			case "no", "node", "nodes":
+				return prompt.FilterContains(getNodeSuggestions(), third, true)
+			case "po", "pod", "pods":
+				return prompt.FilterContains(getPodSuggestions(), third, true)
+			}
+		}
 	default:
 		return []prompt.Suggest{}
 	}

--- a/kube/option.go
+++ b/kube/option.go
@@ -86,6 +86,16 @@ func optionCompleter(args []string, long bool) []prompt.Suggest {
 		suggests = flagAnnotate
 	case "convert":
 		suggests = append(flagConvert, flagGlobal...)
+	case "top":
+		suggests = flagGlobal
+		if len(commandArgs) >= 2 {
+			switch commandArgs[1] {
+			case "no", "node", "nodes":
+				suggests = append(suggests, flagTopNode...)
+			case "po", "pod", "pods":
+				suggests = append(suggests, flagTopPod...)
+			}
+		}
 	case "config":
 		if len(commandArgs) == 2 {
 			switch commandArgs[1] {
@@ -555,6 +565,26 @@ var flagConvert = []prompt.Suggest{
 	{Text: "--sort-by", Description: "If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expression must be an integer or a string."},
 	{Text: "--template", Description: "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview]."},
 	{Text: "--validate", Description: "If true, use a schema to validate the input before sending it"},
+}
+
+var flagTopNode = []prompt.Suggest{
+	{Text: "--heapster-namespace", Description: "Namespace Heapster service is located in."},
+	{Text: "--heapster-port", Description: "Port name in service to use."},
+	{Text: "--heapster-scheme", Description: "Scheme (http or https) to connect to Heapster as."},
+	{Text: "--heapster-service", Description: "Name of Heapster service."},
+	{Text: "-l", Description: "Selector (label query) to filter on"},
+	{Text: "--selector", Description: "Selector (label query) to filter on"},
+}
+
+var flagTopPod = []prompt.Suggest{
+	{Text: "--all-namespaces", Description: "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace."},
+	{Text: "--containers", Description: "If present, print usage of containers within a pod."},
+	{Text: "--heapster-namespace", Description: "Namespace Heapster service is located in."},
+	{Text: "--heapster-port", Description: "Port name in service to use."},
+	{Text: "--heapster-scheme", Description: "Scheme (http or https) to connect to Heapster as."},
+	{Text: "--heapster-service", Description: "Name of Heapster service."},
+	{Text: "-l", Description: "Selector (label query) to filter on"},
+	{Text: "--selector", Description: "Selector (label query) to filter on"},
 }
 
 var flagConfigView = []prompt.Suggest{

--- a/kube/option_arguments.go
+++ b/kube/option_arguments.go
@@ -33,7 +33,7 @@ func completeOptionArguments(d prompt.Document) ([]prompt.Suggest, bool) {
 	switch cmd {
 	case "get", "describe", "create", "delete", "replace", "patch",
 		"edit", "apply", "expose", "rolling-update", "rollout",
-		"label", "annotate", "scale", "convert", "autoscale":
+		"label", "annotate", "scale", "convert", "autoscale", "top":
 		switch option {
 		case "-f", "--filename":
 			return fileCompleter(d), true


### PR DESCRIPTION
I was using kube-prompt one day and noticed that it did not support `kubectl top` functionality.

This PR adds support for `top` including auto-completion for options and flags + auto-suggesting resources.

![final](https://user-images.githubusercontent.com/13400199/39935665-c692de76-5517-11e8-8780-5506d6dc777c.gif)
