### PR TITLE
Fixes #9 - Add -n to namespace completion handler

### DIFF
--- a/kube/option_arguments.go
+++ b/kube/option_arguments.go
@@ -45,7 +45,7 @@ func completeOptionArguments(d prompt.Document) ([]prompt.Suggest, bool) {
 		switch option {
 		case "-f", "--filename":
 			return yamlFileCompleter.Complete(d), true
-		case "--namespace":
+		case "-n", "--namespace":
 			return getNameSpaceSuggestions(), true
 		}
 	}


### PR DESCRIPTION
This allows the user to type something like `get pods -n` and get the same completion information as if they typed `get pods --namespace`