### PR TITLE
Added support to build ARM32 binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ cross: main.go  ## Build binaries for cross platform.
 		zip pkg/kube-prompt_$(VERSION)_darwin_$${arch}.zip kube-prompt; \
 	done;
 	@# linux
-	@for arch in "amd64" "386" "arm64"; do \
+	@for arch in "amd64" "386" "arm64" "arm"; do \
 		GOOS=linux GOARCH=$${arch} make build; \
 		zip pkg/kube-prompt_$(VERSION)_linux_$${arch}.zip kube-prompt; \
 	done;


### PR DESCRIPTION
Currently, Raspberry Pi 4 only has ARM32 support officially (Ubuntu ARM64 doesn't support RPi 4). Raspbian for RPi 4 will only have 32bit armhf support for long time. In order to support K8s cluster composed of RPi4, we need to have binaries built for arm arch.

https://github.com/c-bata/kube-prompt/issues/60