### PR TITLE
Continue if we cannot list namespace

### DIFF
--- a/kube/completer.go
+++ b/kube/completer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/c-bata/go-prompt"
 	"github.com/c-bata/go-prompt/completer"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -36,7 +37,11 @@ func NewCompleter() (*Completer, error) {
 
 	namespaces, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		if err.(*errors.StatusError).Status().Code == 403 {
+			namespaces = nil
+		} else {
+			return nil, err
+		}
 	}
 
 	return &Completer{


### PR DESCRIPTION
To avoid a following error.

```console
$ kube-prompt 
error namespaces is forbidden: User "system:serviceaccount:hoge:hoge" cannot list resource "namespaces" in API group "" at the cluster scope
```