### PR TITLE
Fix panic

### DIFF
--- a/kube/completer.go
+++ b/kube/completer.go
@@ -37,7 +37,7 @@ func NewCompleter() (*Completer, error) {
 
 	namespaces, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
-		if err.(*errors.StatusError).Status().Code == 403 {
+		if statusError, ok := err.(*errors.StatusError); ok && statusError.Status().Code == 403 {
 			namespaces = nil
 		} else {
 			return nil, err


### PR DESCRIPTION
## before
~ kube-prompt
panic: interface conversion: error is *url.Error, not *errors.StatusError

goroutine 1 [running]:
github.com/c-bata/kube-prompt/kube.NewCompleter(0x1ea2a40, 0xc0000fde00, 0xe656a23892ca10dd)
        /Users/xx/go/src/github.com/c-bata/kube-prompt/kube/completer.go:40 +0x486
main.main()
        /Users/xx/go/src/github.com/c-bata/kube-prompt/main.go:23 +0x37

## after
~ kube-prompt
error Get https://192.168.64.7:8443/api/v1/namespaces: dial tcp 192.168.64.7:8443: i/o timeout